### PR TITLE
add json-schema options to FormController

### DIFF
--- a/project/utilities/__init__.py
+++ b/project/utilities/__init__.py
@@ -1,5 +1,28 @@
 import pprint
 
+class EditMode(object):
+    nullmean = False
+    nullable = False
+    editable = False
+    visible = False
+    def __init__(self, val = 0):
+        self.nullmean = (val >= 8)
+        val %= 8
+        self.nullable = (val >= 4)
+        val %= 4
+        self.editable = (val >= 2)
+        val %= 2
+        self.visible = (val >= 1)
+
+    def toValue(self):
+        i = 0
+        i += 1 if self.visible else 0
+        i += 2 if self.editable else 0
+        i += 4 if self.nullable else 0
+        i += 8 if self.nullmean else 0
+        return i
+
+
 class Utility:
 
     @classmethod


### PR DESCRIPTION
voilou bon j'ai fais mes tests sur https://www.jsonschemavalidator.net/ ça a l'air pas mal

pour récupérer le json-schema au lieu du json-bb-formbuilder-classique il faut utiliser le query arg `schema=true`

j'ai traduit ce que je pouvais en utilisant les features json-schema et j'ai rajouté le reste plus ou moins tel quel dans le doute, mais je pense qu'il faudrait faire un tri dans ce qui doit apparaître ou non, à discuter. Egalement certains champs ou il faut probablement faire quelquechose pour que ça ait du sens: ex les tree pickers (thesaurus, position..)

des trucs à discuter quoi avec une vision un peu plus métier, voir les todo notamment